### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/CMakeLists.patch
+++ b/recipe/CMakeLists.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt	2016-11-21 10:27:08.000000000 -0800
++++ CMakeLists.txt	2017-06-05 19:36:55.837393000 -0700
+@@ -637,6 +637,8 @@
+     ENDIF(MSVC)
+   ENDIF(HDF5_C_LIBRARY AND HDF5_HL_LIBRARY AND HDF5_INCLUDE_DIR)
+ 
++  find_package(Threads REQUIRED)
++
+   ###
+   # The following options are not used in Windows.
+   ###

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - dap.path  # [win]
 
 build:
-  number: 4
+  number: 5
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
@@ -30,7 +30,7 @@ requirements:
     - curl
     - zlib 1.2.*
     - hdf4
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py35]
@@ -38,7 +38,7 @@ requirements:
     - curl
     - zlib 1.2.*
     - hdf4
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py35]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     - dim.c.patch  # [win]
     - semantics.c.patch  # [win]
     - dap.path  # [win]
+    - CMakeLists.patch  # [win]
 
 build:
   number: 5


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71