### PR TITLE
Build 4.4.1.1 with patches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,14 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,9 +14,9 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CURL_INCLUDE_DIR=$PREFIX/include \
       -D CURL_LIBRARY=$PREFIX/lib/libcurl${SHLIB_EXT} \
       $SRC_DIR
-make
+make -j$CPU_COUNT
 # ctest  # Run only for the shared lib build to save time.
-make install
+make install -j$CPU_COUNT
 make clean
 
 # Build shared.
@@ -33,6 +33,6 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CURL_INCLUDE_DIR=$PREFIX/include \
       -D CURL_LIBRARY=$PREFIX/lib/libcurl${SHLIB_EXT} \
       $SRC_DIR
-make
+make -j$CPU_COUNT
 ctest
-make install
+make install -j$CPU_COUNT

--- a/recipe/dap.patch
+++ b/recipe/dap.patch
@@ -1,0 +1,57 @@
+diff -Naur netcdf-c-4.4.1.1.orig/libdap2/dapcvt.c netcdf-c-4.4.1.1/libdap2/dapcvt.c
+--- netcdf-c-4.4.1.1.orig/libdap2/dapcvt.c	2016-11-21 16:27:08.000000000 -0200
++++ netcdf-c-4.4.1.1/libdap2/dapcvt.c	2017-04-05 10:45:18.410066978 -0300
+@@ -210,14 +210,15 @@
+ 	ok = 0;
+ 	switch (etype) {
+ 	case NC_BYTE: {
+-		char tmp[128];
+-		
+-		unsigned char* p = (unsigned char*)dstmem;
++	    char* p = (unsigned char*)dstmem;
+ #ifdef _MSC_VER
+-		ok = sscanf(s,"%hC%n",p,&nread);
+-		_ASSERTE(_CrtCheckMemory());
++	    int ival;
++	    ok = sscanf(s,"%d%n",&ival,&nread);
++	    _ASSERTE(_CrtCheckMemory());
++	    if(ival < NC_MIN_BYTE || ival > NC_MAX_BYTE) ok = 0;
++	    *p = (char)ival;
+ #else	
+-		ok = sscanf(s,"%hhu%n",p,&nread);
++	   ok = sscanf(s,"%hhu%n",p,&nread);
+ #endif
+ 	    } break;
+ 	case NC_CHAR: {
+@@ -243,12 +244,15 @@
+ 	case NC_UBYTE: {
+ 	    unsigned char* p = (unsigned char*)dstmem;
+ #ifdef _MSC_VER
+-		ok = sscanf(s, "%hc%n", p,&nread);
+-		_ASSERTE(_CrtCheckMemory());
++	    unsigned int uval;
++	    ok = sscanf(s,"%u%n",&uval,&nread);
++	    _ASSERTE(_CrtCheckMemory());
++	    if(uval > NC_MAX_UBYTE) ok = 0;
++	    *p = (unsigned char)uval;
+ #else
+ 	    ok = sscanf(s,"%hhu%n",p,&nread);
+ #endif
+-		} break;
++	    } break;
+ 	case NC_USHORT: {
+ 	    unsigned short* p = (unsigned short*)dstmem;
+ 	    ok = sscanf(s,"%hu%n",p,&nread);
+diff -Naur netcdf-c-4.4.1.1.orig/libdap2/ncd2dispatch.c netcdf-c-4.4.1.1/libdap2/ncd2dispatch.c
+--- netcdf-c-4.4.1.1.orig/libdap2/ncd2dispatch.c	2016-11-21 16:27:08.000000000 -0200
++++ netcdf-c-4.4.1.1/libdap2/ncd2dispatch.c	2017-04-05 10:45:45.825068343 -0300
+@@ -336,7 +336,8 @@
+     dapcomm->oc.rawurltext = strdup(path);
+ #endif
+ 
+-    ncuriparse(dapcomm->oc.rawurltext,&dapcomm->oc.url);
++    ncstat = ncuriparse(dapcomm->oc.rawurltext,&dapcomm->oc.url);
++	if (!ncstat) goto done;
+ 
+     /* parse the client parameters */
+     ncuridecodeparams(dapcomm->oc.url);

--- a/recipe/dfile.c.patch
+++ b/recipe/dfile.c.patch
@@ -1,0 +1,18 @@
+--- libdispatch\dfile.c.orig	2016-08-10 14:06:27.315735800 +1000
++++ libdispatch\dfile.c	2016-08-10 14:06:36.097008200 +1000
+@@ -166,6 +166,7 @@
+ 	{
+ 	    FILE *fp;
+ 	    size_t i;
++        __int64 file_len = 0;
+ #ifdef HAVE_SYS_STAT_H
+ 	    struct stat st;
+ #endif
+@@ -182,7 +183,6 @@
+ 
+         /* Windows and fstat have some issues, this will work around that. */
+ #ifdef HAVE_FILE_LENGTH_I64
+-        __int64 file_len = 0;
+         if((file_len = _filelengthi64(fileno(fp))) < 0) {
+           fclose(fp);
+           status = errno;

--- a/recipe/dim.c.patch
+++ b/recipe/dim.c.patch
@@ -1,0 +1,19 @@
+--- libsrc\dim.c.orig	2016-08-10 14:20:07.878295000 +1000
++++ libsrc\dim.c	2016-08-10 14:20:17.221986100 +1000
+@@ -444,6 +444,7 @@
+ 	int existid;
+ 	NC_dim *dimp;
+ 	char *newname;		/* normalized */
++    NC_string *old;
+ 
+ 	status = NC_check_id(ncid, &nc); 
+ 	if(status != NC_NOERR)
+@@ -465,7 +466,7 @@
+ 	if(dimp == NULL)
+ 		return NC_EBADDIM;
+ 
+-	NC_string *old = dimp->name;
++	old = dimp->name;
+ 	newname = (char *)utf8proc_NFC((const unsigned char *)unewname);
+ 	if(newname == NULL)
+ 	    return NC_ENOMEM;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.0" %}
+{% set version = "4.4.1.1" %}
 
 package:
   name: libnetcdf
@@ -6,18 +6,22 @@ package:
 
 source:
   url: https://github.com/Unidata/netcdf-c/archive/v{{ version }}.tar.gz
-  sha256: f7d1cb2a82100b9bf9a1130a50bc5c7baf0de5b5022860ac3e09a0a32f83cf4a
+  sha256: 7f040a0542ed3f6d27f3002b074e509614e18d6c515b2005d1537fec01b24909
   patches:
-    # https://github.com/Unidata/netcdf-c/pull/512
-    - back_port_512.patch
+    - dfile.c.patch  # [win]
+    - dim.c.patch  # [win]
+    - semantics.c.patch  # [win]
+    - dap.patch  # [win]
     # https://github.com/Unidata/netcdf-c/pull/573
     - back_port_573.patch
     - CMakeLists.patch  # [win]
 
 build:
-  number: 1
-  skip: True  # [win and py36 or py27]
+  number: 8
+  skip: True  # [win and py36]
   features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
     - vc14  # [win and (py35 or py36)]
 
 requirements:
@@ -30,12 +34,16 @@ requirements:
     - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
     - vc 14  # [win and (py35 or py36)]
   run:
     - curl >=7.44.0,<8
     - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
     - vc 14  # [win and (py35 or py36)]
 
 test:
@@ -46,6 +54,8 @@ test:
     - test -f ${PREFIX}/lib/libnetcdf.dylib  # [osx]
     - ncdump -h "http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic"
     - ncdump -h "https://data.nodc.noaa.gov/thredds/dodsC/ioos/sccoos/scripps_pier/scripps_pier-2016.nc"
+    - ncdump -h "http://oos.soest.hawaii.edu/thredds/dodsC/hioos/model/atm/ncep_pac/NCEP_Pacific_Atmospheric_Model_best.ncd"
+    - ncdump -h "http://oos.soest.hawaii.edu/thredds/dodsC/usgs_dem_10m_tinian"
     - ncdump -h "https://www.ncei.noaa.gov/thredds/dodsC/namanl/201609/20160929/namanl_218_20160929_1800_006.grb"
     - conda inspect linkages -p $PREFIX libnetcdf  # [not win]
     - conda inspect objects -p $PREFIX libnetcdf  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cmake
     - pkg-config  # [not win]
     - msinttypes  # [win]
-    - curl >=7.44.0,<8
+    - curl >=7.54.1,<8
     - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*
@@ -38,7 +38,7 @@ requirements:
     - vc 10  # [win and py34]
     - vc 14  # [win and (py35 or py36)]
   run:
-    - curl >=7.44.0,<8
+    - curl >=7.54.1,<8
     - zlib 1.2.8
     - hdf4
     - hdf5 1.8.18|1.8.18.*

--- a/recipe/semantics.c.patch
+++ b/recipe/semantics.c.patch
@@ -1,0 +1,18 @@
+--- ncgen\semantics.c.orig	2016-11-23 16:47:45.538386400 +1000
++++ ncgen\semantics.c	2016-11-23 17:00:40.896820500 +1000
+@@ -601,6 +601,7 @@
+     int i;
+     int offset = 0;
+     unsigned long totaldimsize;
++    int largealign = 1;
+     if(tsym->touched) return;
+     tsym->touched=1;
+     switch (tsym->subclass) {
+@@ -637,7 +638,6 @@
+ 	    /* now compute the size of the compound based on*/
+ 	    /* what user specified*/
+ 	    offset = 0;
+-            int largealign = 1;
+             for(i=0;i<listlength(tsym->subnodes);i++) {
+               Symbol* field = (Symbol*)listget(tsym->subnodes,i);
+               /* only support 'c' alignment for now*/


### PR DESCRIPTION
@rsignell-usgs this should solve your Windows `curl` issue and backport the https://github.com/Unidata/netcdf-c/pull/573 fix for the  `4.4.1.1`, which is the only one that works to build Python 2.7 extensions.