### PR TITLE
Update hdf5 dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - CMakeLists.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and py36 or py27]
   features:
     - vc14  # [win and (py35 or py36)]
@@ -29,13 +29,13 @@ requirements:
     - curl >=7.44.0,<8
     - zlib 1.2.11
     - hdf4
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1|1.10.1.*
     - vc 14  # [win and (py35 or py36)]
   run:
     - curl >=7.44.0,<8
     - zlib 1.2.11
     - hdf4
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1|1.10.1.*
     - vc 14  # [win and (py35 or py36)]
 
 test:


### PR DESCRIPTION
Hello,

hdf5 1.10.1 is now the base version in anaconda and conda-forge.
I just ran `run_docker_build.sh`, it looks ok.