### PR TITLE
Do not build debug by default

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 # Build static.
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_BUILD_TYPE=Release \
       -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
       -D ENABLE_DAP=ON \
       -D ENABLE_HDF4=ON \
@@ -21,6 +22,7 @@ make clean
 
 # Build shared.
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_BUILD_TYPE=Release \
       -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
       -D ENABLE_DAP=ON \
       -D ENABLE_HDF4=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - CMakeLists.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and py36 or py27]
   features:
     - vc14  # [win and (py35 or py36)]


### PR DESCRIPTION
We will probably need to backport this to 4.5.0 and rebuild netcdf4 to really fix https://github.com/conda-forge/netcdf4-feedstock/issues/44

@isuruf can you take a quick look?