### PR TITLE
ENABLE_CDF5=ON

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cmake -G "NMake Makefiles" ^
       -D ZLIB_LIBRARY=%LIBRARY_LIB%\zlib.lib ^
       -D ZLIB_INCLUDE_DIR=%LIBRARY_INC% ^
       -D CMAKE_BUILD_TYPE=Release ^
+      -D ENABLE_CDF5=ON ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,7 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D ENABLE_LOGGING=ON \
       -D CURL_INCLUDE_DIR=$PREFIX/include \
       -D CURL_LIBRARY=$PREFIX/lib/libcurl${SHLIB_EXT} \
+      -D ENABLE_CDF5=ON \
       $SRC_DIR
 make -j$CPU_COUNT
 # ctest  # Run only for the shared lib build to save time.
@@ -34,6 +35,7 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D ENABLE_LOGGING=ON \
       -D CURL_INCLUDE_DIR=$PREFIX/include \
       -D CURL_LIBRARY=$PREFIX/lib/libcurl${SHLIB_EXT} \
+      -D ENABLE_CDF5=ON \
       -D ENABLE_HDF4_FILE_TESTS=OFF \
       $SRC_DIR
 make -j$CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - CMakeLists.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and py36 or py27]
   features:
     - vc14  # [win and (py35 or py36)]
@@ -36,7 +36,6 @@ requirements:
 
 test:
   commands:
-    - nc-config --all  # [not win]
     - test -f ${PREFIX}/lib/libnetcdf.a  # [not win]
     - test -f ${PREFIX}/lib/libnetcdf.so  # [linux]
     - test -f ${PREFIX}/lib/libnetcdf.dylib  # [osx]
@@ -45,6 +44,7 @@ test:
     - ncdump -h "http://oos.soest.hawaii.edu/thredds/dodsC/hioos/model/atm/ncep_pac/NCEP_Pacific_Atmospheric_Model_best.ncd"
     - ncdump -h "http://oos.soest.hawaii.edu/thredds/dodsC/usgs_dem_10m_tinian"
     - ncdump -h "https://www.ncei.noaa.gov/thredds/dodsC/namanl/201609/20160929/namanl_218_20160929_1800_006.grb"
+    - nc-config --all  # [not win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 


### PR DESCRIPTION
Should address https://github.com/conda-forge/libnetcdf-feedstock/issues/42#issuecomment-382822008

Checking the build log locally that returns the `--has-cdf5 -> yes` as expected.

Ping @czender.