### PR TITLE
use relative path in CMAKE_INSTALL_LIBDIR

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,7 +32,7 @@ fi
 
 # Build static.
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-      -DCMAKE_INSTALL_LIBDIR:PATH=${PREFIX}/lib \
+      -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DENABLE_DAP=ON \
       -DENABLE_HDF4=ON \
@@ -54,7 +54,7 @@ make clean
 
 # Build shared.
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-      -DCMAKE_INSTALL_LIBDIR:PATH=${PREFIX}/lib \
+      -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DENABLE_DAP=ON \
       -DENABLE_HDF4=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - higher_timeout.patch
 
 build:
-  number: 10
+  number: 11
   run_exports:
     #   https://abi-laboratory.pro/tracker/timeline/netcdf/
     - {{ pin_subpackage('libnetcdf') }}


### PR DESCRIPTION
The nc-config template combines CMAKE_INSTALL_PREFIX with
CMAKE_INSTALL_LIBDIR when generating paths.  This requires that
CMAKE_INSTALL_LIBDIR be relative to CMAKE_INSTALL_PREFIX

closes #57