### PR TITLE
Patch to install ncexternl.h in v 4.7.1

### DIFF
--- a/.ci_support/win_c_compilervs2015vc14.yaml
+++ b/.ci_support/win_c_compilervs2015vc14.yaml
@@ -1,5 +1,3 @@
-CMAKE_GENERATOR:
-- NMake Makefiles
 bzip2:
 - '1'
 c_compiler:

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @beckermr @groutr @kmuehlbauer @mingwandroid @msarahan @ocefpaf
+* @beckermr @groutr @kmuehlbauer @mingwandroid @msarahan @ocefpaf @xylar

--- a/README.md
+++ b/README.md
@@ -189,4 +189,5 @@ Feedstock Maintainers
 * [@mingwandroid](https://github.com/mingwandroid/)
 * [@msarahan](https://github.com/msarahan/)
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.7.2" %}
-{% set build = 0 %}
+{% set version = "4.7.1" %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -14,7 +14,7 @@ package:
 
 source:
   url: https://github.com/Unidata/netcdf-c/archive/v{{ version }}.tar.gz
-  sha256: 7648db7bd75fdd198f7be64625af7b276067de48a49dcdfd160f1c2ddff8189c
+  sha256: 583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c
   patches:
     - patches/0003-Add-find_package-Threads-REQUIRED-to-CMakeLists.txt.patch
     - patches/0004-Prefer-getenv-TOPSRCDIR-over-STRINGIFY-TOPSRCDIR.patch
@@ -22,6 +22,7 @@ source:
     - patches/0008-Finish-the-missing-code-to-handle-VS-in-test_common..patch
     - patches/prevent_MS_runtime_libs_being_installed_again.patch  # [win]
     - patches/strdup.patch
+    - patches/0009-include-ncexternl-h.patch
 
 build:
   number: {{ build }}
@@ -105,3 +106,4 @@ extra:
     - mingwandroid
     - msarahan
     - beckermr
+    - xylar

--- a/recipe/patches/0009-include-ncexternl-h.patch
+++ b/recipe/patches/0009-include-ncexternl-h.patch
@@ -1,0 +1,12 @@
+index 9f34b80..97bf41c 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeListFix.txt
+@@ -28,6 +28,10 @@ IF(ENABLE_PNETCDF OR ENABLE_PARALLEL4)
+   INSTALL(FILES ${netCDF_SOURCE_DIR}/include/netcdf_par.h
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+     COMPONENT headers)
++
++  INSTALL(FILES ${netCDF_SOURCE_DIR}/include/ncexternl.h
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++    COMPONENT headers)
+ ENDIF()


### PR DESCRIPTION
This file is imported in netcdf_par.h and is needed by parallel builds of netcdf4 (see conda-forge/netcdf4-feedstock#95)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
