### PR TITLE
stricter pin due to upstream breakage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.7.4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -53,7 +53,7 @@ build:
 
   run_exports:
     #   https://abi-laboratory.pro/tracker/timeline/netcdf/
-    - {{ pin_subpackage('libnetcdf') }} {{ build_pin }}
+    - {{ pin_subpackage('libnetcdf', max_pin='x.x.x.x') }} {{ build_pin }}
 
 requirements:
   build:


### PR DESCRIPTION
Upstream does not promise SEMVER and this is the second time micro release broken backwards compatibility. So let's put a tighter pin here to be on the safe side.

Ping @beckermr 