### PR TITLE
Use CMAKE_PREFIX_PATH

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -26,14 +26,6 @@ jobs:
       echo "Fast Finish"
       
 
-  - script: |
-      echo "Removing homebrew from Azure to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-    displayName: Remove homebrew
-
   - bash: |
       echo "##vso[task.prependpath]$CONDA/bin"
       sudo chown -R $USER $CONDA
@@ -43,6 +35,13 @@ jobs:
       source activate base
       conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
     displayName: 'Add conda-forge-ci-setup=2'
+
+  - script: |
+      echo "Mangling homebrew from Azure to avoid conflicts."
+      source activate base
+      /usr/bin/sudo mangle_homebrew
+      /usr/bin/sudo -k
+    displayName: Mangle homebrew
 
   - script: |
       source activate base

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -74,11 +74,6 @@ jobs:
       displayName: conda-forge build setup
     
 
-    - script: |
-        rmdir C:\strawberry /s /q
-      continueOnError: true
-      displayName: remove strawberryperl
-
     # Special cased version setting some more things!
     - script: |
         call activate base

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,14 +12,12 @@ cmake -G "NMake Makefiles" ^
       -DENABLE_TESTS=ON ^
       -DENABLE_HDF4=ON ^
       -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
-      -DZLIB_LIBRARY="%LIBRARY_LIB%\zlib.lib" ^
-      -DZLIB_INCLUDE_DIR="%LIBRARY_INC%" ^
       -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
       -D ENABLE_CDF5=ON ^
       %SRC_DIR%
 if errorlevel 1 exit \b 1
 
-cmake --build . --config %BUILD_TYPE%
+cmake --build . --config %BUILD_TYPE% --target install
 if errorlevel 1 exit \b 1
 
 :: We need to add some entries to PATH before running the tests
@@ -36,5 +34,3 @@ goto end_tests
 ctest -VV
 :end_tests
 
-cmake --build . --config %BUILD_TYPE% --target install
-if errorlevel 1 exit \b 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,6 +50,7 @@ fi
 # Build static.
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DCMAKE_INSTALL_LIBDIR="lib" \
+      -DCMAKE_PREFIX_PATH=${PREFIX} \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DENABLE_DAP=ON \
       -DENABLE_HDF4=ON \
@@ -60,20 +61,18 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_DOXYGEN=OFF \
       -DCMAKE_C_FLAGS_RELEASE=${CFLAGS} \
       -DCMAKE_C_FLAGS_DEBUG=${CFLAGS} \
-      -DCURL_INCLUDE_DIR=${PREFIX}/include \
-      -DCURL_LIBRARY=${PREFIX}/lib/libcurl${SHLIB_EXT} \
       -DENABLE_CDF5=ON \
       ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
       ${SRC_DIR}
-make -j${CPU_COUNT} ${VERBOSE_CM}
 # ctest  # Run only for the shared lib build to save time.
-make install -j${CPU_COUNT}
+make install -j${CPU_COUNT} ${VERBOSE_CM}
 make clean
 
 # Build shared.
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DCMAKE_INSTALL_LIBDIR="lib" \
+      -DCMAKE_PREFIX_PATH=${PREFIX} \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
       -DENABLE_DAP=ON \
       -DENABLE_HDF4=ON \
@@ -84,15 +83,12 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_DOXYGEN=OFF \
       -DCMAKE_C_FLAGS_RELEASE=${CFLAGS} \
       -DCMAKE_C_FLAGS_DEBUG=${CFLAGS} \
-      -DCURL_INCLUDE_DIR=${PREFIX}/include \
-      -DCURL_LIBRARY=${PREFIX}/lib/libcurl${SHLIB_EXT} \
       -DENABLE_CDF5=ON \
       ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
       ${SRC_DIR}
-make -j${CPU_COUNT} ${VERBOSE_CM}
-make install -j${CPU_COUNT}
-ctest -VV --output-on-failure
+make install -j${CPU_COUNT} ${VERBOSE_CM}
+ctest -VV --output-on-failure -j${CPU_COUNT}
 
 if [[ ${c_compiler} != "toolchain_c" ]]; then
     # Fix build paths in cmake artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.7.4" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
Dont path manually lib paths, let CMAKE_PREFIX_PATH do its job.
Manually setting lib paths with wrong slashes prevented the automatic replace for windows.
Closes #101 

@conda-forge-admin please rerender