### PR TITLE
Fix multiple ref to ocdebug

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.7.4" %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -25,6 +25,7 @@ source:
     - patches/strdup.patch
     - patches/do_not_use_16_processes_in_tests.patch  # [ppc64le]
     - patches/fix-474-for-new-curl.patch
+    - patches/ocdebug.patch  # [unix]
 
 build:
   number: {{ build }}

--- a/recipe/patches/ocdebug.patch
+++ b/recipe/patches/ocdebug.patch
@@ -1,0 +1,13 @@
+diff --git a/ncdump/ocprint.c b/ncdump/ocprint.c
+index d429181b..c8288229 100644
+--- a/ncdump/ocprint.c
++++ b/ncdump/ocprint.c
+@@ -56,7 +56,7 @@ char* optarg;
+ /*Mnemonic*/
+ #define TOPLEVEL 1
+ 
+-int ocdebug;
++extern int ocdebug;
+ 
+ static OCerror ocstat;
+ static OClink glink;


### PR DESCRIPTION
build fails on osx,
I applied just the fix suggested from https://github.com/Unidata/netcdf-c/issues/1725
this seems actually fixed after https://github.com/Unidata/netcdf-c/pull/1732, but other patches may conflict

@conda-forge-admin please rerender