### PR TITLE
Avoid hard-coding paths in cmake config files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -107,8 +107,10 @@ ctest -VV --output-on-failure -j${CPU_COUNT}
 if [[ ${c_compiler} != "toolchain_c" ]]; then
     # Fix build paths in cmake artifacts
     for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do
-        sed -i.bak "s#${BUILD_PREFIX}#\$ENV\{BUILD_PREFIX\}#g" ${fname}
+        sed -i.bak "s#${CONDA_BUILD_SYSROOT}/usr/lib/lib\([a-z]*\).so#\1#g" ${fname}
+        sed -i.bak "s#/Applications/Xcode_.*app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.*sdk/usr/lib/lib\([a-z]*\).dylib#\1#g" ${fname}
         rm ${fname}.bak
+        cat ${fname}
     done
 
     # Fix build paths in nc-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.7.4" %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
We can replace sysroot (linux) or xcode (osx) paths by only the lib name, cmake will do the rest.

Closes #110