### PR TITLE
zarr support

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -26,6 +26,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -26,6 +26,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -26,6 +26,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -22,6 +22,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -22,6 +22,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -22,6 +22,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -16,6 +16,8 @@ hdf5:
 - 1.10.6
 jpeg:
 - '9'
+libzip:
+- '1'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -10,9 +10,10 @@ export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
 
 
-endgroup "Start Docker"
+( endgroup "Start Docker" ) 2> /dev/null
 
-startgroup "Configuring conda"
+( startgroup "Configuring conda" ) 2> /dev/null
+
 export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
@@ -36,34 +37,38 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-endgroup "Configuring conda"
+
+( endgroup "Configuring conda" ) 2> /dev/null
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda debug"
+
     # Drop into an interactive shell
     /bin/bash
 else
-    startgroup "Running conda $BUILD_CMD"
     conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-    endgroup "Running conda build"
-    startgroup "Validating outputs"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
-    endgroup "Validating outputs"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-        endgroup "Uploading packages"
     fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
 fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -13,18 +13,23 @@ function startgroup {
         travis )
             echo "$1"
             echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
         * )
             echo "$1";;
     esac
-}
+} 2> /dev/null
 
 function endgroup {
     # End a foldable group of log lines
     # Pass a single argument, quoted
+
     case ${CI:-} in
         azure )
             echo "##[endgroup]";;
         travis )
             echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
     esac
-}
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -7,7 +7,7 @@
 
 source .scripts/logging_utils.sh
 
-startgroup "Configure Docker"
+( startgroup "Configure Docker" ) 2> /dev/null
 
 set -xeo pipefail
 
@@ -69,9 +69,11 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
-endgroup "Configure Docker"
 
-startgroup "Start Docker"
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
@@ -95,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -2,16 +2,19 @@
 
 source .scripts/logging_utils.sh
 
-set -x
+set -xe
 
-startgroup "Installing a fresh version of Miniforge"
+( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b
-endgroup "Installing a fresh version of Miniforge"
 
-startgroup "Configuring conda"
+( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+
 BUILD_CMD=build
 
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
@@ -34,22 +37,24 @@ echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 
 
-endgroup "Configuring conda"
 
-set -e
+( endgroup "Configuring conda" ) 2> /dev/null
 
-startgroup "Running conda $BUILD_CMD"
+
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
 conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
-endgroup "Running conda build"
-startgroup "Validating outputs"
+( startgroup "Validating outputs" ) 2> /dev/null
+
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
-endgroup "Validating outputs"
+
+( endgroup "Validating outputs" ) 2> /dev/null
+
+( startgroup "Uploading packages" ) 2> /dev/null
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  startgroup "Uploading packages"
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
-  endgroup "Uploading packages"
 fi
+
+( endgroup "Uploading packages" ) 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Installing `libnetcdf` from the `conda-forge` channel can be achieved by adding 
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `libnetcdf` can be installed with:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,6 +19,9 @@ cmake -LAH -G "NMake Makefiles" ^
       -DHDF5_HL_LIBRARY="%LIBRARY_LIB:\=/%/hdf5_hl.lib" ^
       -DHDF5_INCLUDE_DIR="%LIBRARY_INC:\=/%" ^
       -DCMAKE_C_FLAGS="-DH5_BUILT_AS_DYNAMIC_LIB" ^
+      -DENABLE_NCZARR=on ^
+      -DENABLE_NCZARR_S3=off ^
+      -DENABLE_NCZARR_S3_TESTS=off ^
       %SRC_DIR%
 if errorlevel 1 exit \b 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -102,7 +102,7 @@ ctest -VV --output-on-failure -j${CPU_COUNT}
 
 SKIP=""
 # Skip failing test on ppc74le
-if [ ${target_platform} == "linux-ppc64le" ]; then
+if [[ ${target_platform} == "linux-ppc64le" ]]; then
  SKIP="-E nc_test"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,17 +50,16 @@ else
     ENABLE_HDF4=ON
 fi
 
-if [[ ${target_platform} == "linux-ppc64le" ]]; then
-    export CFLAGS=${CFLAGS//-O3/-O0}
-    echo CHANGING CFLAGS: ${CFLAGS}
-    export CMAKE_ARGS=${CMAKE_ARGS//-O3/-O0}
-    echo CHANGING CMAKE ARGS: ${CMAKE_ARGS}
-fi
-
 if [[ ${DEBUG_C} == yes ]]; then
   CMAKE_BUILD_TYPE=Debug
 else
   CMAKE_BUILD_TYPE=Release
+fi
+
+if [[ ${target_platform} == "linux-ppc64le" ]]; then
+    export CFLAGS=${CFLAGS//-O3/-O0}
+    # This is the easiest way to get CMake to stop appending -O3
+    CMAKE_BUILD_TYPE=None
 fi
 
 # Build static.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -51,8 +51,10 @@ else
 fi
 
 if [[ ${target_platform} == "linux-ppc64le" ]]; then
-    export CFLAGS=$(echo "${CFLAGS}" | sed "s/-O3/-O0/g")
+    export CFLAGS=${CFLAGS//-O3/-O0}
     echo CHANGING CFLAGS: ${CFLAGS}
+    export CMAKE_ARGS=${CMAKE_ARGS//-O3/-O0}
+    echo CHANGING CMAKE ARGS: ${CMAKE_ARGS}
 fi
 
 if [[ ${DEBUG_C} == yes ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -106,7 +106,7 @@ if [ ${target_platform} == "linux-ppc64le" ]; then
  SKIP="-E nc_test"
 fi
 
-ctest -VV --output-on-failure -j${CPU_COUNT} "${SKIP}"
+ctest -VV --output-on-failure -j${CPU_COUNT} ${SKIP}
 
 # Fix build paths in cmake artifacts
 for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -98,7 +98,6 @@ cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_NCZARR_S3_TESTS=off \
       ${SRC_DIR}
 make install -j${CPU_COUNT} ${VERBOSE_CM}
-ctest -VV --output-on-failure -j${CPU_COUNT}
 
 SKIP=""
 # Skip failing test on ppc74le

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -78,6 +78,9 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_BYTERANGE=ON \
       ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
+      -DENABLE_NCZARR=on \
+      -DENABLE_NCZARR_S3=off \
+      -DENABLE_NCZARR_S3_TESTS=off \
       ${SRC_DIR}
 # ctest  # Run only for the shared lib build to save time.
 make install -j${CPU_COUNT} ${VERBOSE_CM}
@@ -100,6 +103,9 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_CDF5=ON \
       ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
+      -DENABLE_NCZARR=on \
+      -DENABLE_NCZARR_S3=off \
+      -DENABLE_NCZARR_S3_TESTS=off \
       ${SRC_DIR}
 make install -j${CPU_COUNT} ${VERBOSE_CM}
 ctest -VV --output-on-failure -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,6 +50,11 @@ else
     ENABLE_HDF4=ON
 fi
 
+if [[ ${target_platform} == "linux-ppc64le" ]]; then
+    export CFLAGS=$(echo "${CFLAGS}" | sed "s/-O3/-O0/g")
+    echo CHANGING CFLAGS: ${CFLAGS}
+fi
+
 if [[ ${DEBUG_C} == yes ]]; then
   CMAKE_BUILD_TYPE=Debug
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
   export PARALLEL="-DENABLE_PARALLEL4=ON -DENABLE_PARALLEL_TESTS=ON"
   export CC=mpicc
@@ -15,30 +17,24 @@ else
   PARALLEL=""
 fi
 
-if [[ ${c_compiler} != "toolchain_c" ]]; then
-    declare -a CMAKE_PLATFORM_FLAGS
-    if [[ ${HOST} =~ .*darwin.* ]]; then
-        CMAKE_PLATFORM_FLAGS+=(-DCMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}")
-        # We have a problem with over-stripping of dylibs in the test programs:
-        # nm ${PREFIX}/lib/libdf.dylib | grep error_top
-        #   000000000006197c S _error_top
-        # Then, despite this being linked to explicitly when creating the test programs:
-        # ./hdf4_test_tst_chunk_hdf4
-        # dyld: Symbol not found: _error_top
-        #   Referenced from: ${PREFIX}/lib/libmfhdf.0.dylib
-        #   Expected in: flat namespace
-        #  in ${PREFIX}/lib/libmfhdf.0.dylib
-        # Abort trap: 56
-        # Now clearly libmfhdf should autoload libdf but it does not and that is not going to change:
-        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=556439
-        # .. so we must remove our unused stripping instead :-(
-        # (it may be possible to arrange this symbol to be in the 'D'ata section instead of 'S'
-        #  (symbol in a section other than those above according to man nm), instead though
-        #  or to fix ld64 so that it checks for symbols being used in this section).
-        export LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,-dead_strip_dylibs//g")
-    else
-        CMAKE_PLATFORM_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE="${RECIPE_DIR}/cross-linux.cmake")
-    fi
+if [[ ${HOST} =~ .*darwin.* ]]; then
+    # We have a problem with over-stripping of dylibs in the test programs:
+    # nm ${PREFIX}/lib/libdf.dylib | grep error_top
+    #   000000000006197c S _error_top
+    # Then, despite this being linked to explicitly when creating the test programs:
+    # ./hdf4_test_tst_chunk_hdf4
+    # dyld: Symbol not found: _error_top
+    #   Referenced from: ${PREFIX}/lib/libmfhdf.0.dylib
+    #   Expected in: flat namespace
+    #  in ${PREFIX}/lib/libmfhdf.0.dylib
+    # Abort trap: 56
+    # Now clearly libmfhdf should autoload libdf but it does not and that is not going to change:
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=556439
+    # .. so we must remove our unused stripping instead :-(
+    # (it may be possible to arrange this symbol to be in the 'D'ata section instead of 'S'
+    #  (symbol in a section other than those above according to man nm), instead though
+    #  or to fix ld64 so that it checks for symbols being used in this section).
+    export LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,-dead_strip_dylibs//g")
 fi
 
 # hmaarrfk, 2020/05/04:
@@ -61,7 +57,7 @@ else
 fi
 
 # Build static.
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_PREFIX_PATH=${PREFIX} \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
@@ -72,11 +68,8 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_TESTS=ON \
       -DBUILD_UTILITIES=ON \
       -DENABLE_DOXYGEN=OFF \
-      -DCMAKE_C_FLAGS_RELEASE=${CFLAGS} \
-      -DCMAKE_C_FLAGS_DEBUG=${CFLAGS} \
       -DENABLE_CDF5=ON \
       -DENABLE_BYTERANGE=ON \
-      ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
       -DENABLE_NCZARR=on \
       -DENABLE_NCZARR_S3=off \
@@ -87,7 +80,7 @@ make install -j${CPU_COUNT} ${VERBOSE_CM}
 make clean
 
 # Build shared.
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DCMAKE_INSTALL_LIBDIR="lib" \
       -DCMAKE_PREFIX_PATH=${PREFIX} \
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
@@ -98,10 +91,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DENABLE_TESTS=ON \
       -DBUILD_UTILITIES=ON \
       -DENABLE_DOXYGEN=OFF \
-      -DCMAKE_C_FLAGS_RELEASE=${CFLAGS} \
-      -DCMAKE_C_FLAGS_DEBUG=${CFLAGS} \
       -DENABLE_CDF5=ON \
-      ${CMAKE_PLATFORM_FLAGS[@]} \
       ${PARALLEL} \
       -DENABLE_NCZARR=on \
       -DENABLE_NCZARR_S3=off \
@@ -118,16 +108,14 @@ fi
 
 ctest -VV --output-on-failure -j${CPU_COUNT} "${SKIP}"
 
-if [[ ${c_compiler} != "toolchain_c" ]]; then
-    # Fix build paths in cmake artifacts
-    for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do
-        sed -i.bak "s#${CONDA_BUILD_SYSROOT}/usr/lib/lib\([a-z]*\).so#\1#g" ${fname}
-        sed -i.bak "s#/Applications/Xcode_.*app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.*sdk/usr/lib/lib\([a-z]*\).dylib#\1#g" ${fname}
-        rm ${fname}.bak
-        cat ${fname}
-    done
+# Fix build paths in cmake artifacts
+for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do
+    sed -i.bak "s#${CONDA_BUILD_SYSROOT}/usr/lib/lib\([a-z]*\).so#\1#g" ${fname}
+    sed -i.bak "s#/Applications/Xcode_.*app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.*sdk/usr/lib/lib\([a-z]*\).dylib#\1#g" ${fname}
+    rm ${fname}.bak
+    cat ${fname}
+done
 
-    # Fix build paths in nc-config
-    sed -i.bak "s#${BUILD_PREFIX}/bin/${CC}#${CC}#g" ${PREFIX}/bin/nc-config
-    rm ${PREFIX}/bin/nc-config.bak
-fi
+# Fix build paths in nc-config
+sed -i.bak "s#${BUILD_PREFIX}/bin/${CC}#${CC}#g" ${PREFIX}/bin/nc-config
+rm ${PREFIX}/bin/nc-config.bak

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -110,6 +110,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
 make install -j${CPU_COUNT} ${VERBOSE_CM}
 ctest -VV --output-on-failure -j${CPU_COUNT}
 
+SKIP=""
 # Skip failing test on ppc74le
 if [ ${target_platform} == "linux-ppc64le" ]; then
  SKIP="-E nc_test"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -106,10 +106,6 @@ cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} \
 make install -j${CPU_COUNT} ${VERBOSE_CM}
 
 SKIP=""
-# Skip failing test on ppc74le
-if [[ ${target_platform} == "linux-ppc64le" ]]; then
- SKIP="-E nc_test"
-fi
 
 ctest -VV --output-on-failure -j${CPU_COUNT} ${SKIP}
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -110,6 +110,13 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
 make install -j${CPU_COUNT} ${VERBOSE_CM}
 ctest -VV --output-on-failure -j${CPU_COUNT}
 
+# Skip failing test on ppc74le
+if [ ${target_platform} == "linux-ppc64le" ]; then
+ SKIP="-E nc_test"
+fi
+
+ctest -VV --output-on-failure -j${CPU_COUNT} "${SKIP}"
+
 if [[ ${c_compiler} != "toolchain_c" ]]; then
     # Fix build paths in cmake artifacts
     for fname in `ls ${PREFIX}/lib/cmake/netCDF/*`; do

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.8.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
[According to the docs](https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/nczarr_head.html#nczarr_cmake) the defaults are:

```
The necessary CMake flags are as follows (with defaults)

-DENABLE_NCZARR=on – equivalent to the Automake –enable-nczarr option.
-DENABLE_NCZARR_S3=off – equivalent to the Automake –enable-nczarr-s3 option.
-DENABLE_NCZARR_S3_TESTS=off – equivalent to the Automake –enable-nczarr-s3-tests option.
```

I added those anyway to see if we can enable the feature. I'll turn the test on in the next commits.