### PR TITLE
Use more run exports to avoid pulling in static libraries

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
   strategy:
     matrix:
       osx_64_mpimpich:

--- a/README.md
+++ b/README.md
@@ -275,3 +275,6 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@xylar](https://github.com/xylar/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/README.md
+++ b/README.md
@@ -275,6 +275,3 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@xylar](https://github.com/xylar/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.8.1" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,15 +83,8 @@ requirements:
     - libzip
   run:
     - {{ mpi }}  # [mpi != 'nompi']
-    - bzip2
     - curl
-    - zlib
-    - hdf4
     - hdf5 * {{ mpi_prefix }}_*
-    - jpeg
-    - libzip
-    # Curl should be pulling this... Investigate it later.
-    - libssh2  # [win]
 
 test:
   commands:


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #143.


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.
