### PR TITLE
Backport fix for Unidata/netcdf-c#2674

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -15,7 +15,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -15,7 +15,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -15,7 +15,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_mpinompi.yaml
+++ b/.ci_support/osx_arm64_mpinompi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - vs2019
 hdf4:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @WardF @dopplershift @groutr @kmuehlbauer @mingwandroid @msarahan @ocefpaf @xylar
+* @WardF @dopplershift @groutr @kmuehlbauer @mingwandroid @msarahan @ocefpaf @xylar @zklaus

--- a/README.md
+++ b/README.md
@@ -277,4 +277,5 @@ Feedstock Maintainers
 * [@msarahan](https://github.com/msarahan/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@xylar](https://github.com/xylar/)
+* [@zklaus](https://github.com/zklaus/)
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,6 +48,7 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
     #  or to fix ld64 so that it checks for symbols being used in this section).
     export LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,-dead_strip_dylibs//g")
     export HDF5_PLUGIN_PATH=$(echo "H5_DEFAULT_PLUGINDIR" | clang-cpp -P -include $PREFIX/include/H5pubconf.h - | tr -d '"')
+    export CMAKE_ARGS="${CMAKE_ARGS} -DHAVE_CLOCK_GETTIME:BOOL=OFF"
 else
     export HDF5_PLUGIN_PATH=$(echo "H5_DEFAULT_PLUGINDIR" | $CPP -P -include $PREFIX/include/H5pubconf.h - | tr -d '"')
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.9.2" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -20,6 +20,7 @@ source:
     - patches/0009-topsrcdir.patch
     - patches/prevent_MS_runtime_libs_being_installed_again.patch  # [win]
     - patches/do_not_use_16_processes_in_tests.patch  # [ppc64le]
+    - patches/0001-Fix-issue-2674.patch
 
 build:
   number: {{ build }}
@@ -107,3 +108,4 @@ extra:
     - msarahan
     - xylar
     - dopplershift
+    - zklaus

--- a/recipe/patches/0001-Fix-issue-2674.patch
+++ b/recipe/patches/0001-Fix-issue-2674.patch
@@ -1,0 +1,56 @@
+From b61e5cb9022b98312e6135bda859108352b531f0 Mon Sep 17 00:00:00 2001
+From: uweschulzweida <35592488+uweschulzweida@users.noreply.github.com>
+Date: Wed, 5 Apr 2023 18:05:53 +0200
+Subject: [PATCH] Fix issue #2674
+
+---
+ libhdf5/hdf5open.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/libhdf5/hdf5open.c b/libhdf5/hdf5open.c
+index cb2491ff..e00f426e 100644
+--- a/libhdf5/hdf5open.c
++++ b/libhdf5/hdf5open.c
+@@ -1205,12 +1205,14 @@ static int get_quantize_info(NC_VAR_INFO_T *var)
+ {
+     hid_t attid;
+     hid_t datasetid;
++    htri_t attr_exists;
+ 
+     /* Try to open an attribute of the correct name for quantize
+      * info. */
+     datasetid = ((NC_HDF5_VAR_INFO_T *)var->format_var_info)->hdf_datasetid;
+-    attid = H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_BITGROOM_ATT_NAME,
+-			    H5P_DEFAULT, H5P_DEFAULT);
++    attr_exists = H5Aexists(datasetid, NC_QUANTIZE_BITGROOM_ATT_NAME);
++    attid = attr_exists ? H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_BITGROOM_ATT_NAME,
++			    H5P_DEFAULT, H5P_DEFAULT) : 0;
+ 
+     if (attid > 0)
+       {
+@@ -1218,16 +1220,18 @@ static int get_quantize_info(NC_VAR_INFO_T *var)
+       }
+     else
+       {
+-	attid = H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_GRANULARBR_ATT_NAME,
+-			    H5P_DEFAULT, H5P_DEFAULT);
++        attr_exists = H5Aexists(datasetid, NC_QUANTIZE_GRANULARBR_ATT_NAME);
++	attid = attr_exists ? H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_GRANULARBR_ATT_NAME,
++			    H5P_DEFAULT, H5P_DEFAULT) : 0;
+ 	if (attid > 0)
+ 	  {
+ 	    var->quantize_mode = NC_QUANTIZE_GRANULARBR;
+ 	  }
+ 	else
+ 	  {
+-	    attid = H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_BITROUND_ATT_NAME,
+-				    H5P_DEFAULT, H5P_DEFAULT);
++            attr_exists = H5Aexists(datasetid, NC_QUANTIZE_BITROUND_ATT_NAME);
++	    attid = attr_exists ? H5Aopen_by_name(datasetid, ".", NC_QUANTIZE_BITROUND_ATT_NAME,
++				    H5P_DEFAULT, H5P_DEFAULT) : 0;
+ 	    if (attid > 0)
+ 	      var->quantize_mode = NC_QUANTIZE_BITROUND;
+ 	  }
+-- 
+2.39.1
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This hopefully fixes the issue of overly abundant HDF5-DIAG messages that has plagued a number of downstream projects.