### PR TITLE
Fix error accessing data on S3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.9.3" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -19,6 +19,7 @@ source:
     - patches/0004-Prefer-getenv-TOPSRCDIR-over-STRINGIFY-TOPSRCDIR.patch
     - patches/0009-topsrcdir.patch
     - patches/do_not_use_16_processes_in_tests.patch  # [ppc64le]
+    - patches/fix-s3-support.patch
 
 build:
   number: {{ build }}

--- a/recipe/patches/fix-s3-support.patch
+++ b/recipe/patches/fix-s3-support.patch
@@ -1,0 +1,19 @@
+commit 2905cdc7679f10f8fe2414557fb4b10fc2b4ac1c
+Author: Ward Fisher <wfisher@ucar.edu>
+Date:   Fri Sep 5 15:32:44 2025 -0600
+
+    Added a fallback of us-east-1 as the default AWS default region if there is no other region defined.
+
+diff --git a/libdispatch/ds3util.c b/libdispatch/ds3util.c
+index 9626e2ee1..2d3d0a64e 100644
+--- a/libdispatch/ds3util.c
++++ b/libdispatch/ds3util.c
+@@ -761,7 +761,7 @@ NC_getdefaults3region(NCURI* uri, const char** regionp)
+ 	}
+     }
+     if(region == NULL)
+-	  region = NC_getglobalstate()->aws.default_region; /* Force use of the Amazon default */
++	  region = (NC_getglobalstate()->aws.default_region ? NC_getglobalstate()->aws.default_region : "us-east-1"); /* Force use of the Amazon default */
+ #ifdef AWSDEBUG
+     fprintf(stderr,">>> activeregion = |%s|\n",region);
+ #endif


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This grabs Unidata/netcdf-c#3164 to fix accessing some S3 data. For instance, the following errors on conda-forge currently with 4.9.3, but worked with 4.9.2:

```sh
ncdump -h https://noaa-goes19.s3.amazonaws.com/ABI-L1b-RadC/2025/247/20/OR_ABI-L1b-RadC-M6C02_G19_s20252472016172_e20252472018545_c20252472018578.nc#mode=bytes
```
with the message:
```
ncdump: https://noaa-goes19.s3.amazonaws.com/ABI-L1b-RadC/2025/247/20/OR_ABI-L1b-RadC-M6C02_G19_s20252472016172_e20252472018545_c20252472018578.nc#mode=bytes: NetCDF: S3 error
```

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
