### PR TITLE
Patch /utf-8 flag issue on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: ce160f9c1483b32d1ba8b7633d7984510259e4e439c48a218b95a023dc02fd4c
   patches:
     - patches/do_not_use_16_processes_in_tests.patch  # [ppc64le]
-    # https://github.com/Unidata/netcdf-c/issues/XXXX
+    # https://github.com/Unidata/netcdf-c/issues/3362
     - patches/fix-utf8-public-flag.patch  # [win]
 
 build:
@@ -25,7 +25,7 @@ build:
   {% if mpi != "nompi" %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% else %}
-  {% set mpi_prefix = "nommi" %}
+  {% set mpi_prefix = "nompi" %}
   {% endif %}
   # add build string so packages can depend on
   # mpi or nompi variants

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.10.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -17,13 +17,15 @@ source:
   sha256: ce160f9c1483b32d1ba8b7633d7984510259e4e439c48a218b95a023dc02fd4c
   patches:
     - patches/do_not_use_16_processes_in_tests.patch  # [ppc64le]
+    # https://github.com/Unidata/netcdf-c/issues/XXXX
+    - patches/fix-utf8-public-flag.patch  # [win]
 
 build:
   number: {{ build }}
   {% if mpi != "nompi" %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% else %}
-  {% set mpi_prefix = "nompi" %}
+  {% set mpi_prefix = "nommi" %}
   {% endif %}
   # add build string so packages can depend on
   # mpi or nompi variants

--- a/recipe/patches/fix-utf8-public-flag.patch
+++ b/recipe/patches/fix-utf8-public-flag.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -138,7 +138,7 @@
+ 
+ if(MSVC)
+   set(GLOBAL PROPERTY USE_FOLDERS ON)
+-  target_compile_options(netcdf PUBLIC "/utf-8")
++  target_compile_options(netcdf PRIVATE "/utf-8")
+ endif()
+ 
+ # auto-configure style checks, other CMake modules.


### PR DESCRIPTION
Fix for https://github.com/Unidata/netcdf-c/issues/3362

The `target_compile_options(netcdf PUBLIC "/utf-8")` on [line 140 of CMakeLists.txt](https://github.com/Unidata/netcdf-c/blob/d64f3d9e00c9b610debdadc0fc7c4f1bf9c0822e/CMakeLists.txt#L140) causes build failures for downstream projects that link against netCDF::netcdf on Windows but use a non-MSVC compiler (e.g. MinGW/gfortran).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
